### PR TITLE
Ignore concurrent gc times

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
             - name: Execute Gradle build
-              run:  ./gradlew test -tests io.github.cdsap.kotlinprocess.InfoKotlinProcessBuildService
+              run:  ./gradlew test --tests io.github.cdsap.kotlinprocess.InfoKotlinProcessPluginTest
               env:
                 GE_URL: ${{ secrets.GE_URL }}
                 GE_API_KEY: ${{ secrets.GE_API_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,25 +2,27 @@ name: Run Gradle on PRs
 on:
   pull_request:
   push:
-      branches: main
+      branches: [main, test_different_jvm_executions_parameters]
 jobs:
     prBranch:
         timeout-minutes: 300
         strategy:
             matrix:
                 os: [ubuntu-latest,macos-latest]
+                version: [8, 11, 17, 19]
+                vendor: [temurin, zulu, liberica]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-java@v3
               with:
-                  distribution: temurin
-                  java-version: 11
+                  distribution:  ${{ matrix.vendor }}
+                  java-version:  ${{ matrix.version }}
 
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
             - name: Execute Gradle build
-              run:  ./gradlew test
+              run:  ./gradlew test -tests io.github.cdsap.kotlinprocess.InfoKotlinProcessBuildService
               env:
                 GE_URL: ${{ secrets.GE_URL }}
                 GE_API_KEY: ${{ secrets.GE_API_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest,macos-latest]
-                version: [8, 11, 17, 19]
+                version: [11, 17, 19]
                 vendor: [temurin, zulu, liberica]
         runs-on: ${{ matrix.os }}
         steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,4 +43,4 @@ jobs:
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
             - name: Execute Gradle build
-              run:  /gradlew test --tests io.github.cdsap.kotlinprocess.InfoKotlinProcessPluginTest
+              run:  ./gradlew test --tests io.github.cdsap.kotlinprocess.InfoKotlinProcessPluginTest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,27 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest,macos-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-java@v3
+              with:
+                  distribution: temurin
+                  java-version: 11
+
+            - name: Setup Gradle
+              uses: gradle/gradle-build-action@v2
+            - name: Execute Gradle build
+              run:  ./gradlew test -PexcludeTests=*.InfoKotlinProcessPluginTest
+              env:
+                GE_URL: ${{ secrets.GE_URL }}
+                GE_API_KEY: ${{ secrets.GE_API_KEY }}
+
+    integrationJavaTests:
+        timeout-minutes: 300
+        strategy:
+            matrix:
+                os: [ubuntu-latest,macos-latest]
                 version: [11, 17, 19]
                 vendor: [temurin, zulu, liberica]
         runs-on: ${{ matrix.os }}
@@ -22,7 +43,4 @@ jobs:
             - name: Setup Gradle
               uses: gradle/gradle-build-action@v2
             - name: Execute Gradle build
-              run:  ./gradlew test --tests io.github.cdsap.kotlinprocess.InfoKotlinProcessPluginTest
-              env:
-                GE_URL: ${{ secrets.GE_URL }}
-                GE_API_KEY: ${{ secrets.GE_API_KEY }}
+              run:  /gradlew test --tests io.github.cdsap.kotlinprocess.InfoKotlinProcessPluginTest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Run Gradle on PRs
 on:
   pull_request:
   push:
-      branches: [main, test_different_jvm_executions_parameters]
+      branches: [main]
 jobs:
     prBranch:
         timeout-minutes: 300

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,14 @@ dependencies {
     implementation("com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3")
     testImplementation("junit:junit:4.13.2")
 }
+tasks.withType<Test>().configureEach {
+    filter {
 
+        if (project.hasProperty("excludeTests")) {
+            excludeTest(project.property("excludeTests").toString(),"")
+        }
+    }
+}
 gradlePlugin {
     plugins {
         create("InfoKotlinProcessPlugin") {

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/parser/JStatData.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/parser/JStatData.kt
@@ -46,6 +46,10 @@ class JStatData {
         return processes
     }
 
+    // When using ParallelGC argument concurrent gc times are not informed, generating an output like
+    //Timestamp    S0C    S1C    S0U   S1U   EC   EU    OC   OU   MC   MU   CCSC   CCSU   YGC   YGCT FGC FGCT  CGC  CGCT GCT
+    //   298.0     22.0   20.0  0.0    0.0   1.0  1.8   1.0  0.9  4.0  8.3   6.0    5.0    4    0.3   4   0.7   -    -    1
+    // We need to remove the entries CGC and CGCT from the headers and values
     private fun removeConcurrentGCTimes(
         rawHeaders: List<String>,
         rawValues: List<String>

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/parser/JStatData.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/parser/JStatData.kt
@@ -50,7 +50,8 @@ class JStatData {
         rawHeaders: List<String>,
         rawValues: List<String>
     ): Pair<List<String>, List<String>> {
-        return if (rawHeaders.contains("CGC") && rawHeaders.contains("CGCT")) {
+        return if (rawHeaders.contains("CGC") && rawHeaders.contains("CGCT")
+            && rawHeaders.size == rawValues.size ) {
             val concurrentGCTime = rawHeaders.indexOf("CGC")
             val concurrentGCTimeTotal = rawHeaders.indexOf("CGCT")
 

--- a/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
+++ b/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
@@ -1,61 +1,37 @@
 package io.github.cdsap.kotlinprocess
 
 import junit.framework.TestCase.assertTrue
-import org.gradle.internal.impldep.org.junit.Assume.assumeTrue
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 class InfoKotlinProcessPluginTest {
+
+    private val gradleVersions = listOf("7.5.1", "7.6", "8.0.1")
+
     @Rule
     @JvmField
     val testProjectDir = TemporaryFolder()
 
     @Test
     fun testOutputIsGeneratedWhenPluginIsApplied() {
-        testProjectDir.newFile("build.gradle").appendText(
-            """
-                plugins {
-                    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
-                    id 'application'
-                    id 'io.github.cdsap.kotlinprocess'
-                }
-                repositories {
-                    mavenCentral()
-                }
-            """.trimIndent()
-        )
-        listOf("7.5.1", "7.6", "8.0.1").forEach {
-            val build = GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--info")
-                .withPluginClasspath()
-                .withGradleVersion(it)
-                .build()
-            assertTrue(build.output.contains("Kotlin processes"))
-            assertTrue(build.output.contains("PID"))
-            assertTrue(build.output.contains("Capacity"))
-            assertTrue(build.output.contains("Uptime"))
+        createBuildGradle()
+        createKotlinClass()
+
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
         }
     }
+
 
     @Test
     fun testPluginIsCompatibleWithConfigurationCacheWithoutGradleEnterprise() {
-        testProjectDir.newFile("build.gradle").appendText(
-            """
-                plugins {
-                    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
-                    id 'application'
-                    id 'io.github.cdsap.kotlinprocess'
-                }
-                repositories {
-                    mavenCentral()
-                }
+        createBuildGradle()
 
-            """.trimIndent()
-        )
-        listOf("7.5.1", "7.6", "8.0.1").forEach {
+       gradleVersions.forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
                 .withArguments("compileKotlin", "--configuration-cache")
@@ -68,63 +44,129 @@ class InfoKotlinProcessPluginTest {
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
+
             assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
             assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
         }
     }
 
+    @Test
+    fun testOutputIsGeneratedWhenPluginIsAppliedWithJvmArgs() {
+        testProjectDir.newFile("gradle.properties").appendText("""
+            org.gradle.jvmargs=-Xmx256m -Dfile.encoding=UTF-8
+        """.trimIndent())
+        createBuildGradle()
+        createKotlinClass()
+
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
+        }
+    }
 
     @Test
-    fun testPluginIsCompatibleWithConfigurationCacheWithGradleEnterprise() {
-        assumeTrue(
-            "Gradle Enterprise URL and Access Key are set",
-            System.getenv("GE_URL") != null && System.getenv("GE_API_KEY") != null
-        )
+    fun testOutputIsGeneratedWhenPluginIsAppliedWithJvmArgsAndKotlinJvm() {
+        testProjectDir.newFile("gradle.properties").appendText("""
+            org.gradle.jvmargs=-Xmx256m -Dfile.encoding=UTF-8
+            kotlin.daemon.jvmargs=-Xmx128m
+        """.trimIndent())
+        createBuildGradle()
+        createKotlinClass()
 
-        testProjectDir.newFile("settings.gradle").appendText(
-            """
-                plugins {
-                    id 'com.gradle.enterprise' version '3.12.2'
-                }
-                gradleEnterprise {
-                    server = "${System.getenv("GE_URL")}"
-                    accessKey="${System.getenv("GE_API_KEY")}"
-                    buildScan {
-                        capture { taskInputFiles = true }
-                        publishAlways()
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
+        }
+    }
 
-                    }
-                }
-            """.trimIndent()
-        )
+    @Test
+    fun testOutputIsGeneratedWhenPluginIsAppliedWithJvmArgsAndKotlinGCJvm() {
+        testProjectDir.newFile("gradle.properties").appendText("""
+            org.gradle.jvmargs=-Xmx256m -Dfile.encoding=UTF-8
+            kotlin.daemon.jvmargs=-Xmx128m -XX:+UseParallelGC
+        """.trimIndent())
+        createBuildGradle()
+        createKotlinClass()
+
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
+        }
+    }
+
+    @Test
+    fun testOutputIsGeneratedWhenPluginIsAppliedWithJvmGCArgsAndKotlinJvm() {
+        testProjectDir.newFile("gradle.properties").appendText("""
+            org.gradle.jvmargs=-Xmx256m -XX:+UseParallelGC -Dfile.encoding=UTF-8
+        """.trimIndent())
+        createBuildGradle()
+        createKotlinClass()
+
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
+        }
+    }
+
+    @Test
+    fun testOutputIsGeneratedWhenPluginIsAppliedWithJvmGCArgsAndKotlinGCJvm() {
+        testProjectDir.newFile("gradle.properties").appendText("""
+            org.gradle.jvmargs=-Xmx256m -XX:+UseParallelGC -Dfile.encoding=UTF-8
+            kotlin.daemon.jvmargs=-Xmx128m -XX:+UseParallelGC
+        """.trimIndent())
+        createBuildGradle()
+        createKotlinClass()
+
+        gradleVersions.forEach {
+            val build = simpleKotlinCompileBuild(it)
+            assertTerminalOutput(build)
+        }
+    }
+
+    private fun simpleKotlinCompileBuild(it: String): BuildResult = GradleRunner.create()
+        .withProjectDir(testProjectDir.root)
+        .withArguments("compileKotlin", "--info")
+        .withPluginClasspath()
+        .withGradleVersion(it)
+        .withDebug(true)
+        .build()
+
+    private fun assertTerminalOutput(build: BuildResult) {
+        print(build.output)
+        assertTrue(build.output.contains("Kotlin processes"))
+        assertTrue(build.output.contains("PID"))
+        assertTrue(build.output.contains("Capacity"))
+        assertTrue(build.output.contains("Uptime"))
+        assertTrue(build.output.contains("minutes"))
+        assertTrue(build.output.contains("Gb"))
+    }
+
+    private fun createBuildGradle() {
         testProjectDir.newFile("build.gradle").appendText(
             """
-                plugins {
-                    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
-                    id 'application'
-                    id 'io.github.cdsap.kotlinprocess'
-                }
-                repositories {
-                    mavenCentral()
-                }
-
-            """.trimIndent()
+                    plugins {
+                        id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+                        id 'application'
+                        id 'io.github.cdsap.kotlinprocess'
+                    }
+                    repositories {
+                        mavenCentral()
+                    }
+                """.trimIndent()
         )
-        listOf("7.5.1", "7.6", "8.0.1").forEach {
-            val firstBuild = GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
-                .withPluginClasspath()
-                .withGradleVersion(it)
-                .build()
-            val secondBuild = GradleRunner.create()
-                .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
-                .withPluginClasspath()
-                .withGradleVersion(it)
-                .build()
-            assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
-            assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
-        }
+    }
+
+    private fun createKotlinClass() {
+        testProjectDir.newFolder("src/main/kotlin/com/example")
+        testProjectDir.newFile("src/main/kotlin/com/example/Hello.kt").appendText(
+            """
+                    package com.example
+                    class Hello() {
+                      fun print() {
+                        println("hello")
+                      }
+                    }
+                    """.trimIndent()
+        )
     }
 }

--- a/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginWtihBuildScanTest.kt
+++ b/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginWtihBuildScanTest.kt
@@ -1,4 +1,68 @@
 package io.github.cdsap.kotlinprocess
 
+import junit.framework.TestCase
+import org.gradle.internal.impldep.org.junit.Assume
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
 class InfoKotlinProcessPluginWtihBuildScanTest {
+
+    @Rule
+    @JvmField
+    val testProjectDir = TemporaryFolder()
+    @Test
+    fun testPluginIsCompatibleWithConfigurationCacheWithGradleEnterprise() {
+        Assume.assumeTrue(
+            "Gradle Enterprise URL and Access Key are set",
+            System.getenv("GE_URL") != null && System.getenv("GE_API_KEY") != null
+        )
+
+        testProjectDir.newFile("settings.gradle").appendText(
+            """
+                plugins {
+                    id 'com.gradle.enterprise' version '3.12.2'
+                }
+                gradleEnterprise {
+                    server = "${System.getenv("GE_URL")}"
+                    accessKey="${System.getenv("GE_API_KEY")}"
+                    buildScan {
+                        capture { taskInputFiles = true }
+                        publishAlways()
+
+                    }
+                }
+            """.trimIndent()
+        )
+        testProjectDir.newFile("build.gradle").appendText(
+            """
+                plugins {
+                    id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+                    id 'application'
+                    id 'io.github.cdsap.kotlinprocess'
+                }
+                repositories {
+                    mavenCentral()
+                }
+
+            """.trimIndent()
+        )
+        listOf("8.0.1").forEach {
+            val firstBuild = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("compileKotlin", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(it)
+                .build()
+            val secondBuild = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("compileKotlin", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(it)
+                .build()
+            TestCase.assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
+            TestCase.assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
+        }
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginWtihBuildScanTest.kt
+++ b/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginWtihBuildScanTest.kt
@@ -1,0 +1,4 @@
+package io.github.cdsap.kotlinprocess
+
+class InfoKotlinProcessPluginWtihBuildScanTest {
+}


### PR DESCRIPTION
Issue #12 raised no build values/output are shown in build scan/terminal.

Thanks to the comments on the issue we found the origin when using `UseParallelGC`.  The output when executing `jstat $Process` is:
```
Timestamp        S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT   
         2988.0 43520.0 43520.0  0.0    0.0   262144.0 259463.8  699392.0   43970.9   65024.0 63998.3 7936.0 7465.0      4    0.043   4      0.137   -          -    0.180
```
without using `UseParallelGC` the result is:
```
Timestamp        S0C    S1C    S0U    S1U      EC       EU        OC         OU       MC     MU    CCSC   CCSU   YGC     YGCT    FGC    FGCT    CGC    CGCT     GCT   
         2438.7  0.0   4096.0  0.0   4096.0 326656.0 304128.0  193536.0   79440.8   101904.0 99506.3 11360.0 10601.7     13    0.080   0      0.000   8      0.008    0.088
```

ParallelGC reports concurrent gc time in the property `FGC` instead of ` CGC ` and  ` CGCT `.

Updated the logic and added integration tests for Java 11,17,19 in different vendors

