### PR TITLE
Updating zgc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Apply the plugin in the main `build.gradle(.kts)` configuration file:
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id("io.github.cdsap.kotlinprocess") version "0.1.3"
+  id("io.github.cdsap.kotlinprocess") version "0.1.4"
 }
 ```
 
@@ -20,7 +20,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("io.github.cdsap:infokotlinprocess:0.1.3")
+    classpath("io.github.cdsap:infokotlinprocess:0.1.4")
   }
 }
 
@@ -31,7 +31,7 @@ apply(plugin = "io.github.cdsap.kotlinprocess")
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id "io.github.cdsap.kotlinprocess" version "0.1.3"
+  id "io.github.cdsap.kotlinprocess" version "0.1.4"
 }
 
 ```
@@ -43,7 +43,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath "io.github.cdsap:infokotlinprocess:0.1.3"
+    classpath "io.github.cdsap:infokotlinprocess:0.1.4"
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.cdsap"
-version = "0.1.3"
+version = "0.1.4"
 
 java {
     toolchain {

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/ConsolidateProcesses.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/ConsolidateProcesses.kt
@@ -26,6 +26,7 @@ class ConsolidateProcesses {
                             capacity = jStatData[it.key]?.capacity?.toGigsFromKb()!!,
                             gcTime = jStatData[it.key]?.gcTime?.toMinutes()!!,
                             uptime = jStatData[it.key]?.uptime?.toMinutes()!!,
+                            type = jStatData[it.key]?.typeGC!!
                         )
                     )
                 }

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/model/Process.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/model/Process.kt
@@ -7,5 +7,6 @@ data class Process(
     val usage: Double,
     val capacity: Double,
     val gcTime: Double,
-    val uptime: Double
+    val uptime: Double,
+    val type: String
 )

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/model/ProcessJstat.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/model/ProcessJstat.kt
@@ -4,5 +4,6 @@ data class ProcessJstat(
     val usage: Double,
     val capacity: Double,
     val gcTime: Double,
-    val uptime: Double
+    val uptime: Double,
+    val typeGC: String
 )

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/output/BuildScanOutput.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/output/BuildScanOutput.kt
@@ -30,6 +30,10 @@ class BuildScanOutput(
                 "Kotlin-Process-${it.pid}-gcTime",
                 "${it.gcTime} minutes"
             )
+            buildScanExtension.value(
+                "Kotlin-Process-${it.pid}-gcType",
+                it.type
+            )
         }
     }
 }

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/output/ConsoleOutput.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/output/ConsoleOutput.kt
@@ -18,7 +18,7 @@ class ConsoleOutput(private val processes: List<Process>) {
                 body {
                     row {
                         cell("Kotlin processes") {
-                            columnSpan = 6
+                            columnSpan = 7
                         }
                     }
                     row {
@@ -27,6 +27,7 @@ class ConsoleOutput(private val processes: List<Process>) {
                         cell("Usage")
                         cell("Capacity")
                         cell("GC Time")
+                        cell("GC Type")
                         cell("Uptime")
                     }
 
@@ -37,6 +38,7 @@ class ConsoleOutput(private val processes: List<Process>) {
                             cell("${it.usage} Gb")
                             cell("${it.capacity} Gb")
                             cell("${it.gcTime} minutes")
+                            cell(it.type)
                             cell("${it.uptime} minutes")
                         }
                     }


### PR DESCRIPTION
When using ZGC in Kotlin daemon the output of jstat -gc is:
```
❯ jstat -gc -t 43352                                                  
Timestamp           S0C         S1C         S0U         S1U          EC           EU           OC           OU          MC         MU       CCSC      CCSU     YGC     YGCT     FGC    FGCT     CGC    CGCT       GCT   
         1113.6           -           -           -           -            -            -      86016.0      81920.0   137920.0   130338.9   15872.0   14056.6      -         -     -         -    36     0.000     0.000
```

This pr address this format and includes a new element in the output BuildScan/Console