### PR TITLE
Update develocity plugin to 3.18.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation("io.github.cdsap:jdk-tools-parser:0.1.1")
     implementation("io.github.cdsap:commandline-value-source:0.1.0")
     implementation("com.jakewharton.picnic:picnic:0.7.0")
-    implementation("com.gradle:develocity-gradle-plugin:3.17.2")
+    implementation("com.gradle:develocity-gradle-plugin:3.18.1")
     implementation("com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3")
     testImplementation("junit:junit:4.13.2")
 }


### PR DESCRIPTION
### Details
- Updates Develocity plugin to `3.18.1` to address the following:
```
- The deprecated "gradleEnterprise.buildScan.buildFinished" API has been replaced by "develocity.buildScan.buildFinished"
- The deprecated "gradleEnterprise.buildScan.value" API has been replaced by "develocity.buildScan.value"
```