### PR TITLE
Reporting when hit configuration cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Apply the plugin in the main `build.gradle(.kts)` configuration file:
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id("io.github.cdsap.kotlinprocess") version "0.1.6"
+  id("io.github.cdsap.kotlinprocess") version "0.1.7"
 }
 ```
 
@@ -20,7 +20,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath("io.github.cdsap:infokotlinprocess:0.1.6")
+    classpath("io.github.cdsap:infokotlinprocess:0.1.7")
   }
 }
 
@@ -31,7 +31,7 @@ apply(plugin = "io.github.cdsap.kotlinprocess")
 Using the plugins DSL:
 ``` groovy
 plugins {
-  id "io.github.cdsap.kotlinprocess" version "0.1.6"
+  id "io.github.cdsap.kotlinprocess" version "0.1.7"
 }
 
 ```
@@ -43,7 +43,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath "io.github.cdsap:infokotlinprocess:0.1.6"
+    classpath "io.github.cdsap:infokotlinprocess:0.1.7"
   }
 }
 
@@ -56,7 +56,7 @@ Build Scan:
 
 ![](images/buildscan.png)
 
-The field `Usage` represents the value obtained at the end of the build using `jstat` on the JVM process. 
+The field `Usage` represents the value obtained at the end of the build using `jstat` on the JVM process.
 
 ### Build Output
 If you are not using Gradle Enterprise, the information about the Kotlin processes will be included at the end of the build:

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessBuildService.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessBuildService.kt
@@ -6,9 +6,12 @@ import io.github.cdsap.kotlinprocess.output.ConsoleOutput
 import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
 
 abstract class InfoKotlinProcessBuildService :
-    BuildService<InfoKotlinProcessBuildService.Params>, AutoCloseable {
+    BuildService<InfoKotlinProcessBuildService.Params>, AutoCloseable,
+    OperationCompletionListener {
     interface Params : BuildServiceParameters {
         var jInfoProvider: Provider<String>
         var jStatProvider: Provider<String>
@@ -25,4 +28,6 @@ abstract class InfoKotlinProcessBuildService :
             ConsoleOutput(processes).print()
         }
     }
+
+    override fun onFinish(event: FinishEvent?) {}
 }

--- a/src/main/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPlugin.kt
@@ -12,6 +12,8 @@ import io.github.cdsap.valuesourceprocess.jStat
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
+import org.gradle.build.event.BuildEventsListenerRegistry
+import org.gradle.kotlin.dsl.support.serviceOf
 
 
 class InfoKotlinProcessPlugin : Plugin<Project> {
@@ -33,12 +35,13 @@ class InfoKotlinProcessPlugin : Plugin<Project> {
     }
 
     private fun consoleReporting(project: Project) {
-        project.gradle.sharedServices.registerIfAbsent(
+        val service = project.gradle.sharedServices.registerIfAbsent(
             "kotlinProcessService", InfoKotlinProcessBuildService::class.java
         ) {
             parameters.jInfoProvider = project.jInfo(nameProcess)
             parameters.jStatProvider = project.jStat(nameProcess)
-        }.get()
+        }
+        project.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(service)
     }
 
     private fun buildScanEnterpriseReporting(

--- a/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
+++ b/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
@@ -10,7 +10,7 @@ import org.junit.rules.TemporaryFolder
 
 class InfoKotlinProcessPluginTest {
 
-    private val gradleVersions = listOf("8.12.1")
+    private val gradleVersions = listOf("8.6", "8.7", "8.12.1")
 
     @Rule
     @JvmField

--- a/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
+++ b/src/test/kotlin/io/github/cdsap/kotlinprocess/InfoKotlinProcessPluginTest.kt
@@ -10,7 +10,7 @@ import org.junit.rules.TemporaryFolder
 
 class InfoKotlinProcessPluginTest {
 
-    private val gradleVersions = listOf("7.6.2", "8.1.1", "8.6", "8.7")
+    private val gradleVersions = listOf("8.12.1")
 
     @Rule
     @JvmField
@@ -35,19 +35,21 @@ class InfoKotlinProcessPluginTest {
         gradleVersions.forEach {
             val firstBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
             val secondBuild = GradleRunner.create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments("compileKotlin", "--configuration-cache")
+                .withArguments("clean", "compileKotlin", "--no-build-cache", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(it)
                 .build()
-
             assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
+            assertTrue(firstBuild.output.contains("Kotlin processes"))
             assertTrue(secondBuild.output.contains("Configuration cache entry reused."))
+            assertTrue(secondBuild.output.contains("Kotlin processes"))
+
         }
     }
 


### PR DESCRIPTION
When not using Develocity and hitting the configuration cache, the entry was not displayed.
This PR adds the OperationCompletionListener that forces the service to wait until the last task executed